### PR TITLE
fix done bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,15 +17,18 @@ function animate (keyframes, timingProperties) {
   assert.ok(Array.isArray(keyframes), 'nanoanimation: keyframes should be an array')
   assert.equal(typeof timingProperties, 'object', 'nanoanimation: timingProperties should be type object')
 
-  return function (element, done) {
+  return function (element, _done) {
+    var done = _done || noop
     assert.equal(typeof element, 'object', 'nanoanimation: element should be type object')
+    assert.equal(typeof done, 'function', 'nanoanimation: done should be type function')
+
     if (typeof window === 'undefined' || !('AnimationEvent' in window)) {
       done()
       return placeholder
     }
 
     var animation = element.animate(keyframes, timingProperties)
-    animation.onfinish = done || noop
+    animation.onfinish = done
     return animation
   }
 }


### PR DESCRIPTION
Hi @yoshuawuyts! 👋 

Just playing with this and noticed a bug.

- when executing outside a browser (SSR) `done` is never set to `noop` so it explodes. This sets `done` to `noop` right away to avoid catastrophe.

- Added an assert to ensure done is passed in as a function. We set `done` to `noop` if its undefined so this keeps `done` optional.

